### PR TITLE
check dtypes for times

### DIFF
--- a/src/scattering_functions/scattering_functions.py
+++ b/src/scattering_functions/scattering_functions.py
@@ -241,6 +241,7 @@ def intermediate_scattering(
     # this is so if there are no frames with a certain dt, we can raise the error before the calculation starts
     # which is a lot less anoying than it failing halfway through
     pairs_at_t = []
+    assert times_at_frame.dtype == t.dtype, "times_at_frame and t must be the same dtype"
     for t_i in range(len(t)):
         pairs = get_frames_with_delta_t(times_at_frame, t[t_i])
         assert len(pairs)


### PR DESCRIPTION
I found a weird bug if the dtypes for t and times_at_frame are different (I had float32 and float64), the `get_frames_with_delta_t` function won't find any frames with a certain dt even if they exist. You could just cast the dtypes to be the same between the arrays, but this seemed more along the lines of the current interface. Feel free to modify this to suit your style!